### PR TITLE
Epic/SOF-6009

### DIFF
--- a/src/include/meta_properties/pseudopotential.js
+++ b/src/include/meta_properties/pseudopotential.js
@@ -3,6 +3,10 @@ import _ from "underscore";
 import { Property } from "../../property";
 
 export class Pseudopotential extends Property {
+    static compatibleExchangeCorrelation = {
+        hse06: ["pbe", "hse06"],
+    };
+
     get path() {
         return this.prop("path");
     }
@@ -68,11 +72,17 @@ export class Pseudopotential extends Property {
      * @param {String} exchangeCorrelation.functional
      */
     static filterRawDataByExchangeCorrelation(rawData, exchangeCorrelation) {
-        return rawData.filter((el) =>
-            Object.keys(exchangeCorrelation).reduce(
-                (mem, key) => mem && el.exchangeCorrelation[key] === exchangeCorrelation[key],
-            ),
+        const { functional } = exchangeCorrelation;
+        const isCompatibleWithOther = Object.keys(this.compatibleExchangeCorrelation).includes(
+            functional,
         );
+        return rawData.filter((item) => {
+            return isCompatibleWithOther
+                ? this.compatibleExchangeCorrelation[functional].includes(
+                      item.exchangeCorrelation?.functional,
+                  )
+                : functional === item.exchangeCorrelation?.functional;
+        });
     }
 
     // filter unique (assuming that path is always unique)

--- a/tests/pseudopotential.test.js
+++ b/tests/pseudopotential.test.js
@@ -145,4 +145,13 @@ describe("Pseudopotentials", () => {
         expect(filtered[0].apps[0]).to.be.equal(filterObj2.appName);
         expect(filtered[0].element).to.be.equal(filterObj2.elements[0]);
     });
+    it("are filtered by compatible functionals", () => {
+        const exchangeCorrelation = { approximation: "hybrid", functional: "hse06" };
+        const sortedPseudos = Pseudopotential.filterRawDataByExchangeCorrelation(
+            pseudos,
+            exchangeCorrelation,
+        );
+        expect(sortedPseudos).to.have.length(3); // there are 3 PBE pseudos above
+        expect(sortedPseudos.map((p) => p.exchangeCorrelation.functional)).to.include("pbe");
+    });
 });


### PR DESCRIPTION
This PR concerns loosening the filtering of pseudopotentials by exchange-correlation functional to include compatible functionals. For example, pseudopotentials based on PBE should also be available for HSE calculations.